### PR TITLE
build: upgrade verdaccio version to 5.30.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.29.2/Dockerfile
+# https://github.com/verdaccio/verdaccio/blob/v5.30.3/Dockerfile
 # FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.11.0-alpine as builder
 FROM node:20.11.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.29.2
+ARG VERDACCIO_DIST_VERSION=5.30.3
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ docker-compose up -d
 
 now only support verdaccio `v5.x`
 
-- change verdaccio version `5.29.2`
+- change verdaccio version `5.30.3`
 
 ## Contributing
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.29.2/Dockerfile
+# https://github.com/verdaccio/verdaccio/blob/v5.30.3/Dockerfile
 # FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.10.0-alpine as builder
 FROM node:20.10.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.29.2
+ARG VERDACCIO_DIST_VERSION=5.30.3
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmmirror.com  \


### PR DESCRIPTION
feat #3

- Update Verdaccio version from 5.29.2 to 5.30.3 in Dockerfile and build.dockerfile
- Update README.md to reflect the change in Verdaccio version