### PR TITLE
feat(verdaccio): update Verdaccio to v5.31.1 and Node.js to v20.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.30.3/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.11.0-alpine as builder
-FROM node:20.11.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v5.31.1/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
+FROM node:20.14.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.30.3
+ARG VERDACCIO_DIST_VERSION=5.31.1
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -45,7 +45,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.11.0-alpine
+FROM node:20.14.0-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ROOT_DIST ?=./out
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=20.11.0-alpine
+ROOT_PARENT_SWITCH_TAG :=20.14.0-alpine
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =node
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ docker-compose up -d
 
 now only support verdaccio `v5.x`
 
-- change verdaccio version `5.30.3`
+- change verdaccio version `5.31.1`
+    - glibc `2.35-r0`
+    - node version `20.14.0`
+    - yarn version `yarn-v1.22.19`
 
 ## Contributing
 

--- a/dist-docker/v5/Dockerfile
+++ b/dist-docker/v5/Dockerfile
@@ -1,40 +1,20 @@
-# This dockerfile uses extends image https://hub.docker.com/sinlov/go-micro-cli
-# VERSION 1
-# Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
-# https://hub.docker.com/_/node?tab=tags&page=1&ordering=last_updated&name=15.12.0-alpine
-
-# maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
-
-# https://github.com/verdaccio/verdaccio/blob/v5.31.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
-FROM node:20.14.0-alpine as builder
-
-ARG VERDACCIO_DIST_VERSION=5.31.1
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
 
 ENV NODE_ENV=production \
-    VERDACCIO_BUILD_REGISTRY=https://registry.npmmirror.com  \
+    VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
     HUSKY_SKIP_INSTALL=1 \
     CI=true \
     HUSKY_DEBUG=1
 
-# proxy settings github pull
-ARG GITHUB_RPOXY_PREFIX=https://ghproxy.net/
-
-# proxy settings apk repo with: mirrors.aliyun.com
-RUN cp /etc/apk/repositories /etc/apk/repositories.bak && \
-  sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
-
 RUN apk add --force-overwrite && \
-    apk --no-cache add openssl ca-certificates wget git && \
+    apk --no-cache add openssl ca-certificates wget && \
     apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3 && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk && \
     apk add --force-overwrite glibc-2.35-r0.apk
 
 WORKDIR /opt/verdaccio-build
-
-RUN git clone ${GITHUB_RPOXY_PREFIX}https://github.com/verdaccio/verdaccio.git --depth=1 -b v${VERDACCIO_DIST_VERSION} /opt/verdaccio-build
+COPY . .
 
 ## build the project and create a tarball of the project for later
 ## global installation
@@ -42,8 +22,6 @@ RUN yarn config set npmRegistryServer $VERDACCIO_BUILD_REGISTRY && \
     yarn config set enableProgressBars true && \
     yarn config set enableScripts false && \
     yarn install --immutable && \
-    yarn add verdaccio-gitea-auth && \
-    yarn add verdaccio-hello && \
     yarn build
 ## pack the project
 RUN yarn pack --out verdaccio.tgz \
@@ -53,7 +31,7 @@ RUN yarn pack --out verdaccio.tgz \
 RUN rm -Rf /opt/verdaccio-build
 
 FROM node:20.14.0-alpine
-LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
+LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \
     VERDACCIO_USER_NAME=verdaccio \
@@ -65,10 +43,6 @@ ENV PATH=$VERDACCIO_APPDIR/docker-bin:$PATH \
 
 WORKDIR $VERDACCIO_APPDIR
 
-# proxy settings apk repo with: mirrors.aliyun.com
-RUN cp /etc/apk/repositories /etc/apk/repositories.bak && \
-  sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
-
 # https://github.com/Yelp/dumb-init
 RUN apk --no-cache add openssl dumb-init
 
@@ -77,10 +51,6 @@ RUN mkdir -p /verdaccio/storage /verdaccio/plugins /verdaccio/conf
 COPY --from=builder /opt/tarball .
 
 USER root
-
-# proxy settings for npm
-RUN npm config set registry https://registry.npmmirror.com
-
 # install verdaccio as a global package so is fully handled by npm
 # ensure none dependency is being missing and is prod by default
 RUN npm install -g $VERDACCIO_APPDIR/verdaccio.tgz \


### PR DESCRIPTION
feat #5

- Update Verdaccio version from 5.30.3 to 5.31.1
- Update Node.js version from 20.11.0 to 20.14.0
- Update glibc to 2.35-r0
- Update yarn to v1.22.19
- Update Dockerfile and Makefile accordingly
- Add new build configuration for v5.31.1