### PR TITLE
feat(verdaccio): update node version to 20.16.0 and verdaccio to 5.32.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.31.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
-FROM node:20.14.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v5.32.2/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.16.0-alpine as builder
+FROM node:20.16.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.31.1
+ARG VERDACCIO_DIST_VERSION=5.32.2
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -45,7 +45,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.14.0-alpine
+FROM node:20.16.0-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ROOT_DIST ?=./out
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=20.14.0-alpine
+ROOT_PARENT_SWITCH_TAG :=20.16.0-alpine
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =node
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ docker-compose up -d
 
 now only support verdaccio `v5.x`
 
-- change verdaccio version `5.31.1`
+- change verdaccio version `5.32.2`
     - glibc `2.35-r0`
-    - node version `20.14.0`
+    - node version `20.16.0`
     - yarn version `yarn-v1.22.19`
 
 ## Contributing

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.31.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
-FROM node:20.14.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v5.32.2/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.16.0-alpine as builder
+FROM node:20.16.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.31.1
+ARG VERDACCIO_DIST_VERSION=5.32.2
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmmirror.com  \
@@ -52,7 +52,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.14.0-alpine
+FROM node:20.16.0-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/dist-docker/v5/Dockerfile
+++ b/dist-docker/v5/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.14.0-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.16.0-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -30,7 +30,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.14.0-alpine
+FROM node:20.16.0-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
feat #7

- Update node version from 20.14.0 to 20.16.0 in Dockerfile and Makefile
- Update verdaccio version from 5.31.1 to 5.32.2 in Dockerfile and README.md
- Update build.dockerfile and dist-docker/v5/Dockerfile to reflect node version change
