### PR TITLE
feat: update verdaccio to v6.0.1 and node to 20.18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ROOT_DIST ?=./out
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=20.16.0-alpine
+ROOT_PARENT_SWITCH_TAG :=20.18.0-alpine
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =node
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -12,18 +12,21 @@
 [![docker hub image pulls](https://img.shields.io/docker/pulls/sinlov/docker-verdaccio-gitea-auth)](https://hub.docker.com/r/sinlov/docker-verdaccio-gitea-auth/tags?page=1&ordering=last_updated)
 
 - docker hub see https://hub.docker.com/r/sinlov/docker-verdaccio-gitea-auth
-- this is fast way to run https://verdaccio.org/ and auth by https://gitea.io/
 
-## fast use
+## Features
 
-```sh
-docker run -d --rm \
-  --name verdaccio-gitea-auth \
-  -p 4873:4873 \
-  sinlov/docker-verdaccio-gitea-auth:latest
-```
+- this is fast way to run https://verdaccio.org/ and auth by https://gitea.io/ or self-hosted gitea server.
+- add healthy check plugin [verdaccio-hello](https://github.com/bruceman/verdaccio-hello) (image version 5.30+)
 
-> WARN: this way not load config and gitea-auth, only test for run container.
+### Migration
+
+#### Migration v5 to v6
+
+from release note [6.0.0](https://github.com/verdaccio/verdaccio/releases/tag/v6.0.0)
+
+> Update notes, no considerable changes on this major release, for npm.js users only dropping Node.js, 14 and 16 support, minimum now is Node.js 18 and no changes for Docker users.
+
+please update to version [5.32.2](https://github.com/verdaccio/verdaccio/releases/tag/v5.32.2) (2024-09-12) before upgrade.
 
 ## devops docker-compose
 
@@ -143,11 +146,11 @@ docker-compose up -d
 
 ### change version
 
-now only support verdaccio `v5.x`
+now support verdaccio `v6.x` `v5.x`
 
-- change verdaccio version `5.32.2`
+- change verdaccio version `6.0.1`
     - glibc `2.35-r0`
-    - node version `20.16.0`
+    - node version `20.18.0`
     - yarn version `yarn-v1.22.19`
 
 ## Contributing

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v5.32.2/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.16.0-alpine as builder
-FROM node:20.16.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v6.0.1/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
+FROM node:20.18.0-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=5.32.2
+ARG VERDACCIO_DIST_VERSION=6.0.1
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmmirror.com  \
@@ -52,7 +52,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.16.0-alpine
+FROM node:20.18.0-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/dist-docker/v6/Dockerfile
+++ b/dist-docker/v6/Dockerfile
@@ -1,16 +1,4 @@
-# This dockerfile uses extends image https://hub.docker.com/sinlov/go-micro-cli
-# VERSION 1
-# Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
-# https://hub.docker.com/_/node?tab=tags&page=1&ordering=last_updated&name=15.12.0-alpine
-
-# maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
-
-# https://github.com/verdaccio/verdaccio/blob/v6.0.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
-FROM node:20.18.0-alpine as builder
-
-ARG VERDACCIO_DIST_VERSION=6.0.1
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -19,15 +7,14 @@ ENV NODE_ENV=production \
     HUSKY_DEBUG=1
 
 RUN apk add --force-overwrite && \
-    apk --no-cache add openssl ca-certificates wget git && \
+    apk --no-cache add openssl ca-certificates wget && \
     apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3 && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk && \
     apk add --force-overwrite glibc-2.35-r0.apk
 
 WORKDIR /opt/verdaccio-build
-
-RUN git clone https://github.com/verdaccio/verdaccio.git --depth=1 -b v${VERDACCIO_DIST_VERSION} /opt/verdaccio-build
+COPY . .
 
 ## build the project and create a tarball of the project for later
 ## global installation
@@ -35,8 +22,6 @@ RUN yarn config set npmRegistryServer $VERDACCIO_BUILD_REGISTRY && \
     yarn config set enableProgressBars true && \
     yarn config set enableScripts false && \
     yarn install --immutable && \
-    yarn add verdaccio-gitea-auth && \
-    yarn add verdaccio-hello && \
     yarn build
 ## pack the project
 RUN yarn pack --out verdaccio.tgz \
@@ -46,7 +31,7 @@ RUN yarn pack --out verdaccio.tgz \
 RUN rm -Rf /opt/verdaccio-build
 
 FROM node:20.18.0-alpine
-LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
+LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \
     VERDACCIO_USER_NAME=verdaccio \


### PR DESCRIPTION
feat #9

- Update verdaccio version from 5.32.2 to 6.0.1
- Update node version from 20.16.0 to 20.18.0
- Update Dockerfile and Makefile accordingly
- Add migration guide in README.md