### PR TITLE
build: update verdaccio version to 6.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v6.0.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
-FROM node:20.18.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v6.0.5/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.1-alpine as builder
+FROM node:20.18.1-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=6.0.1
+ARG VERDACCIO_DIST_VERSION=6.0.5
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -45,7 +45,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.18.0-alpine
+FROM node:20.18.1-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ROOT_DIST ?=./out
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=20.18.0-alpine
+ROOT_PARENT_SWITCH_TAG :=20.18.1-alpine
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =node
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ docker-compose up -d
 
 now support verdaccio `v6.x` `v5.x`
 
-- change verdaccio version `6.0.1`
+- change verdaccio version `6.0.5`
     - glibc `2.35-r0`
-    - node version `20.18.0`
+    - node version `20.18.1`
     - yarn version `yarn-v1.22.19`
 
 ## Contributing

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -6,11 +6,11 @@
 
 # maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
-# https://github.com/verdaccio/verdaccio/blob/v6.0.1/Dockerfile
-# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
-FROM node:20.18.0-alpine as builder
+# https://github.com/verdaccio/verdaccio/blob/v6.0.5/Dockerfile
+# FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.1-alpine as builder
+FROM node:20.18.1-alpine as builder
 
-ARG VERDACCIO_DIST_VERSION=6.0.1
+ARG VERDACCIO_DIST_VERSION=6.0.5
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmmirror.com  \
@@ -52,7 +52,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.18.0-alpine
+FROM node:20.18.1-alpine
 LABEL maintainer="https://github.com/sinlov/docker-verdaccio-gitea-auth"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/dist-docker/v6/Dockerfile
+++ b/dist-docker/v6/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.0-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20.18.1-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org  \
@@ -30,7 +30,7 @@ RUN yarn pack --out verdaccio.tgz \
 ## clean up and reduce bundle size
 RUN rm -Rf /opt/verdaccio-build
 
-FROM node:20.18.0-alpine
+FROM node:20.18.1-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
build #14

- Update node version from 20.18.0 to 20.18.1
- Update verdaccio version from 6.0.1 to 6.0.5
- Update Dockerfiles and Makefile with new versions
- Update README with new verdaccio and node versions